### PR TITLE
Expose the functions "Get-AccessToken" and "Get-AccessTokenWithRefreshToken" from AccessToken.ps1

### DIFF
--- a/AADInternals.psd1
+++ b/AADInternals.psd1
@@ -157,6 +157,8 @@ DISCLAIMER: Functionality provided through this module are not supported by Micr
     "Get-ADFSConfiguration"
     
     # AccessToken.ps1
+    "Get-AccessToken"
+    "Get-AccessTokenWithRefreshToken"
     "Get-AccessTokenForAADGraph"
     "Get-AccessTokenForMSGraph"
     "Get-AccessTokenForPTA"


### PR DESCRIPTION
These functions could be exposed to facilitate scripting.
For instance, the user could specify the resource and the clientID with Get-AADIntAccessToken -Resource "https://graph.microsoft.com" -ClientId "d3590ed6-52b3-4102-aeff-aad2292ab01c" to use the official Microsoft Office client to get an access token for MS Graph, with the permissions Mail.ReadWrite, Files.ReadWrite.All and Group.ReadWrite.All.