### PR TITLE
New SPO function - Add member to a site 

### DIFF
--- a/AADInternals.psd1
+++ b/AADInternals.psd1
@@ -179,6 +179,7 @@ DISCLAIMER: Functionality provided through this module are not supported by Micr
     "Get-AccessTokenForAdmin"
     "Get-AccessTokenForOneNote"
     "Unprotect-EstsAuthPersistentCookie"
+    "Get-UserRealmV2"
     
     # AccessToken_utils.ps1
     "Get-LoginInformation"

--- a/AADInternals.psd1
+++ b/AADInternals.psd1
@@ -301,6 +301,7 @@ DISCLAIMER: Functionality provided through this module are not supported by Micr
     "Get-SPOSiteUsers"
     "Get-SPOSiteGroups"
     "Get-SPOUserProperties"
+    "Get-SPOTest"
 
     # Kerberos.ps1
     "New-KerberosTicket"

--- a/AADInternals.psd1
+++ b/AADInternals.psd1
@@ -179,7 +179,6 @@ DISCLAIMER: Functionality provided through this module are not supported by Micr
     "Get-AccessTokenForAdmin"
     "Get-AccessTokenForOneNote"
     "Unprotect-EstsAuthPersistentCookie"
-    "Get-UserRealmV2"
     
     # AccessToken_utils.ps1
     "Get-LoginInformation"
@@ -292,10 +291,6 @@ DISCLAIMER: Functionality provided through this module are not supported by Micr
 
     # SPO_utils.ps1
     "Get-SPOAuthenticationHeader"
-    "Create-ListFromCollection"
-    "Get-IDCRLToken"
-    "Get-IDCRLCookie"
-    "Get-SPODigest"
 
     # SPO.ps1
     "Get-SPOSiteUsers"

--- a/AADInternals.psd1
+++ b/AADInternals.psd1
@@ -291,6 +291,10 @@ DISCLAIMER: Functionality provided through this module are not supported by Micr
 
     # SPO_utils.ps1
     "Get-SPOAuthenticationHeader"
+    "Create-ListFromCollection"
+    "Get-IDCRLToken"
+    "Get-IDCRLCookie"
+    "Get-SPODigest"
 
     # SPO.ps1
     "Get-SPOSiteUsers"

--- a/AADInternals.psd1
+++ b/AADInternals.psd1
@@ -301,7 +301,7 @@ DISCLAIMER: Functionality provided through this module are not supported by Micr
     "Get-SPOSiteUsers"
     "Get-SPOSiteGroups"
     "Get-SPOUserProperties"
-    "Get-SPOTest"
+    "Set-SPOSiteMembers"
 
     # Kerberos.ps1
     "New-KerberosTicket"

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -480,8 +480,6 @@ function Set-SPOSiteUserProperty
     }
 }
 
-
-# Sep 6th 2020
 function Get-SPOSettings
 {
 <#
@@ -560,6 +558,89 @@ function Get-SPOSettings
         {
             $response[4]
         }
+
+    }
+}
+
+function Get-SPOTest
+{
+<#
+    .SYNOPSIS
+    Gets SharePoint Online settings
+
+    .DESCRIPTION
+    Gets SharePoint Online settings
+
+    .Parameter AccessToken
+    SharePoint Online Access Token
+
+    .Parameter Tenant
+    The tenant name of the organization, ie. company.onmicrosoft.com -> "company"
+
+    .Example
+    PS C:\>Get-AADIntAccessTokenForSPO -Admin -SaveToCache -Tenant company
+    PS C:\>Get-AADIntSPOSettings -Tenant Company
+
+    _ObjectType_                                          : Microsoft.Online.SharePoint.TenantAdministration.Tenant
+    _ObjectIdentity_                                      : 4b09819f-80c3-b000-9cfe-8c850fbea6d5|908bed80-a04a-4433-b4a0-883d9847d110:908c17b8-5ebe-450c-9073-15e52aa1739b
+                                                            Tenant
+    AIBuilderEnabled                                      : False
+    AIBuilderSiteInfoList                                 : {}
+    AIBuilderSiteList                                     : {}
+    AIBuilderSiteListFileName                             : 
+    AllowCommentsTextOnEmailEnabled                       : True
+    AllowDownloadingNonWebViewableFiles                   : True
+    AllowedDomainListForSyncClient                        : {}
+    AllowEditing                                          : True
+    AllowGuestUserShareToUsersNotInSiteCollection         : False
+    AllowLimitedAccessOnUnmanagedDevices                  : False
+    AllowSelectSGsInODBListInTenant                       : 
+    AnyoneLinkTrackUsers                                  : False
+    ApplyAppEnforcedRestrictionsToAdHocRecipients         : True
+    BccExternalSharingInvitations                         : False
+    ...
+
+#>
+    [cmdletbinding()]
+    Param(
+        [Parameter(Mandatory=$False)]
+        [String]$AccessToken,
+        [Parameter(Mandatory=$True)]
+        [String]$Tenant
+    )
+    Process
+    {
+        # Get from cache if not provided
+        $AccessToken = Get-AccessTokenFromCache -AccessToken $AccessToken -Resource "https://$Tenant-admin.sharepoint.com/" -ClientId "9bc3ab49-b65d-410a-85ad-de819febfddc"
+
+       <# $body=@"
+<Request xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="Javascript Library">
+	<Actions>
+		<ObjectPath Id="1" ObjectPathId="0" />
+		<Query Id="2" ObjectPathId="0">
+			<Query SelectAllProperties="true">
+				<Properties />
+			</Query>
+		</Query>
+	</Actions>
+	<ObjectPaths>
+		<Constructor Id="0" TypeId="{268004ae-ef6b-4e9b-8425-127220d84719}" />
+	</ObjectPaths>
+</Request>
+"@#>
+        $headers=@{
+            "Authorization" = "Bearer $AccessToken"
+        }
+
+        
+        # Invoke the request
+        $response=Invoke-RestMethod -UseBasicParsing -Uri "https://$Tenant-admin.sharepoint.com/sites/myg" -Method Post -Headers $headers
+
+        <#if($response.count -gt 4)
+        {
+            $response[4]
+        }#>
+        return $response
 
     }
 }

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -240,8 +240,6 @@ function Get-SPOUserProperties
 
         if($response.StatusCode -eq 200)
         {
-            Write-Host $siteSession
-            Write-Host $authHeader
             [xml]$response=$response.Content
             $entry=$response.entry
 

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -626,8 +626,8 @@ function Get-SPOTest
         $siteSession = Create-WebSession -SetCookieHeader $AuthHeader -Domain $siteDomain
 
         # Invoke the request
-        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
-        
+        #$response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
+        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json" -ErrorAction SilentlyContinue 
         <#if($response.count -gt 4)
         {
             $response[4]

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -637,7 +637,7 @@ function Get-SPOTest
         #$ck = Get-IDCRLCookie -Token $t -Tenant $Tenant
         #$siteSession = Create-WebSession -SetCookieHeader $ah -Domain $siteDomain
         # Invoke the request
-        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/contextinfo" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
+        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
         #$response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json;odata=verbose" -ErrorAction SilentlyContinue  -Headers $headers 
         <#if($response.count -gt 4)
         {

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -623,21 +623,21 @@ function Get-SPOTest
  
         $siteDomain=$Site.Split("/")[2]
         # Create a WebSession object
-        #$siteSession = Create-WebSession -SetCookieHeader $AuthHeader -Domain $siteDomain
-        $digest = Get-SPODigest -Site $Site
+        $siteSession = Create-WebSession -SetCookieHeader $AuthHeader -Domain $siteDomain
+        #$digest = Get-SPODigest -Site $Site
         # Set the headers
-        $headers=@{
+        <#$headers=@{
                 "X-RequestDigest" = $digest
             }
-        Write-Host $digest
+        Write-Host $digest#>
         #$c = Get-Credential
         
         #$t = Get-IDCRLToken 
         #$ck = Get-IDCRLCookie -Token $t -Tenant $Tenant
-        $siteSession = Create-WebSession -SetCookieHeader $ah -Domain $siteDomain
+        #$siteSession = Create-WebSession -SetCookieHeader $ah -Domain $siteDomain
         # Invoke the request
-        #$response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
-        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json" -ErrorAction SilentlyContinue  -Headers $headers 
+        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/contextinfo" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
+        #$response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json;odata=verbose" -ErrorAction SilentlyContinue  -Headers $headers 
         <#if($response.count -gt 4)
         {
             $response[4]

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -608,36 +608,26 @@ function Get-SPOTest
         [Parameter(Mandatory=$False)]
         [String]$AccessToken,
         [Parameter(Mandatory=$True)]
+        [String]$Site,
+        [Parameter(Mandatory=$True)]
         [String]$Tenant
     )
     Process
     {
-        # Get from cache if not provided
-        $AccessToken = Get-AccessTokenFromCache -AccessToken $AccessToken -Resource "https://$Tenant-admin.sharepoint.com/" -ClientId "9bc3ab49-b65d-410a-85ad-de819febfddc"
 
-       <# $body=@"
-<Request xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="Javascript Library">
-	<Actions>
-		<ObjectPath Id="1" ObjectPathId="0" />
-		<Query Id="2" ObjectPathId="0">
-			<Query SelectAllProperties="true">
-				<Properties />
-			</Query>
-		</Query>
-	</Actions>
-	<ObjectPaths>
-		<Constructor Id="0" TypeId="{268004ae-ef6b-4e9b-8425-127220d84719}" />
-	</ObjectPaths>
-</Request>
-"@#>
-        $headers=@{
-            "Authorization" = "Bearer $AccessToken"
-        }
+         # Check the site url
+         if($Site.EndsWith("/"))
+         {
+             $Site=$Site.Substring(0,$Site.Length-1)
+         }
+ 
+        $siteDomain=$Site.Split("/")[2]
+        # Create a WebSession object
+        $siteSession = Create-WebSession -SetCookieHeader $AuthHeader -Domain $siteDomain
 
-        
         # Invoke the request
-        $response=Invoke-RestMethod -UseBasicParsing -Uri "https://$Tenant-admin.sharepoint.com/sites/myg" -Method Post -Headers $headers
-
+        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
+        
         <#if($response.count -gt 4)
         {
             $response[4]

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -606,7 +606,7 @@ function Get-SPOTest
     [cmdletbinding()]
     Param(
         [Parameter(Mandatory=$False)]
-        [String]$AccessToken,
+        [String]$AuthHeader,
         [Parameter(Mandatory=$True)]
         [String]$Site,
         [Parameter(Mandatory=$True)]

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -630,11 +630,11 @@ function Get-SPOTest
                 "X-RequestDigest" = $digest
             }
         Write-Host $digest
-        $c = Get-Credential
+        #$c = Get-Credential
         
-        $t = Get-IDCRLToken -Credentials $c
-        $ck = Get-IDCRLCookie -Token $t -Tenant $Tenant
-        $siteSession = Create-WebSession -SetCookieHeader $ck -Domain $siteDomain
+        #$t = Get-IDCRLToken 
+        #$ck = Get-IDCRLCookie -Token $t -Tenant $Tenant
+        $siteSession = Create-WebSession -SetCookieHeader $ah -Domain $siteDomain
         # Invoke the request
         #$response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
         $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json" -ErrorAction SilentlyContinue  -Headers $headers 

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -637,7 +637,13 @@ function Get-SPOTest
         #$ck = Get-IDCRLCookie -Token $t -Tenant $Tenant
         #$siteSession = Create-WebSession -SetCookieHeader $ah -Domain $siteDomain
         # Invoke the request
-        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
+        $headers=@{
+            #    "X-RequestDigest" = $digest
+            }
+        Get-AccessTokenForSPO -Tenant $Tenant -SaveToCache
+        $AccessToken = Get-AccessTokenFromCache -AccessToken $AccessToken -Resource "https://$Tenant.sharepoint.com/" -ClientId "9bc3ab49-b65d-410a-85ad-de819febfddc"
+        $headers["Authorization"] = "Bearer $AccessToken"
+        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession  -Headers $headers  -ErrorAction SilentlyContinue 
         #$response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json;odata=verbose" -ErrorAction SilentlyContinue  -Headers $headers 
         <#if($response.count -gt 4)
         {

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -637,7 +637,7 @@ function Get-SPOTest
         #$ck = Get-IDCRLCookie -Token $t -Tenant $Tenant
         #$siteSession = Create-WebSession -SetCookieHeader $ah -Domain $siteDomain
         # Invoke the request
-        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
+        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/contextinfo" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
         #$response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json;odata=verbose" -ErrorAction SilentlyContinue  -Headers $headers 
         <#if($response.count -gt 4)
         {

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -623,6 +623,7 @@ function Get-SPOTest
  
         $siteDomain=$Site.Split("/")[2]
         # Create a WebSession object
+        Write-Host $siteDomain
         $siteSession = Create-WebSession -SetCookieHeader $AuthHeader -Domain $siteDomain
         #$digest = Get-SPODigest -Site $Site
         # Set the headers

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -624,10 +624,14 @@ function Get-SPOTest
         $siteDomain=$Site.Split("/")[2]
         # Create a WebSession object
         $siteSession = Create-WebSession -SetCookieHeader $AuthHeader -Domain $siteDomain
-
+        $digest = Get-SPODigest -Site $Site
+        # Set the headers
+        $headers=@{
+                "X-RequestDigest" = $digest
+            }
         # Invoke the request
         #$response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
-        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json" -ErrorAction SilentlyContinue 
+        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json" -ErrorAction SilentlyContinue  -Headers $headers 
         <#if($response.count -gt 4)
         {
             $response[4]

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -623,12 +623,18 @@ function Get-SPOTest
  
         $siteDomain=$Site.Split("/")[2]
         # Create a WebSession object
-        $siteSession = Create-WebSession -SetCookieHeader $AuthHeader -Domain $siteDomain
+        #$siteSession = Create-WebSession -SetCookieHeader $AuthHeader -Domain $siteDomain
         $digest = Get-SPODigest -Site $Site
         # Set the headers
         $headers=@{
                 "X-RequestDigest" = $digest
             }
+        Write-Host $digest
+        $c = Get-Credential
+        
+        $t = Get-IDCRLToken -Credentials $c
+        $ck = Get-IDCRLCookie -Token $t -Tenant $Tenant
+        $siteSession = Create-WebSession -SetCookieHeader $ck -Domain $siteDomain
         # Invoke the request
         #$response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession -ErrorAction SilentlyContinue 
         $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json" -ErrorAction SilentlyContinue  -Headers $headers 

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -623,7 +623,6 @@ function Get-SPOTest
  
         $siteDomain=$Site.Split("/")[2]
         # Create a WebSession object
-        Write-Host $siteDomain
         $siteSession = Create-WebSession -SetCookieHeader $AuthHeader -Domain $siteDomain
         #$digest = Get-SPODigest -Site $Site
         # Set the headers
@@ -643,7 +642,7 @@ function Get-SPOTest
         $at = Get-AccessTokenForSPO -Tenant $Tenant -SaveToCache
         #$AccessToken = Get-AccessTokenFromCache -AccessToken $AccessToken -Resource "https://$Tenant.sharepoint.com/" -ClientId "9bc3ab49-b65d-410a-85ad-de819febfddc"
         $headers["Authorization"] = "Bearer $at"
-        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession  -Headers $headers  -ErrorAction SilentlyContinue 
+        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/contextinfo" -Method Get -WebSession $siteSession  -Headers $headers  -ErrorAction SilentlyContinue 
         #$response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json;odata=verbose" -ErrorAction SilentlyContinue  -Headers $headers 
         <#if($response.count -gt 4)
         {

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -606,7 +606,7 @@ function Get-SPOTest
     [cmdletbinding()]
     Param(
         [Parameter(Mandatory=$False)]
-        [String]$AuthHeader,
+        [String]$AccessToken,
         [Parameter(Mandatory=$True)]
         [String]$Site,
         [Parameter(Mandatory=$True)]
@@ -621,9 +621,9 @@ function Get-SPOTest
              $Site=$Site.Substring(0,$Site.Length-1)
          }
  
-        $siteDomain=$Site.Split("/")[2]
+        #$siteDomain=$Site.Split("/")[2]
         # Create a WebSession object
-        $siteSession = Create-WebSession -SetCookieHeader $AuthHeader -Domain $siteDomain
+        #$siteSession = Create-WebSession -SetCookieHeader $AuthHeader -Domain $siteDomain
         #$digest = Get-SPODigest -Site $Site
         # Set the headers
         <#$headers=@{
@@ -639,10 +639,13 @@ function Get-SPOTest
         $headers=@{
             #    "X-RequestDigest" = $digest
             }
-        $at = Get-AccessTokenForSPO -Tenant $Tenant -SaveToCache
+        $body=@{
+            "resource" = "https://loki.delve.office.com"
+        }
+        $at = Get-AccessTokenFromCache -AccessToken $AccessToken -Resource "https://$Tenant-admin.sharepoint.com/" 
         #$AccessToken = Get-AccessTokenFromCache -AccessToken $AccessToken -Resource "https://$Tenant.sharepoint.com/" -ClientId "9bc3ab49-b65d-410a-85ad-de819febfddc"
         $headers["Authorization"] = "Bearer $at"
-        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/contextinfo" -Method Get -WebSession $siteSession  -Headers $headers  -ErrorAction SilentlyContinue 
+        $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.OAuth.Token/Acquire" -Method Post -Headers $headers  -ErrorAction SilentlyContinue -ContentType "application/json" -Body ($body | ConvertTo-Json)
         #$response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json;odata=verbose" -ErrorAction SilentlyContinue  -Headers $headers 
         <#if($response.count -gt 4)
         {

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -640,9 +640,9 @@ function Get-SPOTest
         $headers=@{
             #    "X-RequestDigest" = $digest
             }
-        Get-AccessTokenForSPO -Tenant $Tenant -SaveToCache
-        $AccessToken = Get-AccessTokenFromCache -AccessToken $AccessToken -Resource "https://$Tenant.sharepoint.com/" -ClientId "9bc3ab49-b65d-410a-85ad-de819febfddc"
-        $headers["Authorization"] = "Bearer $AccessToken"
+        $at = Get-AccessTokenForSPO -Tenant $Tenant -SaveToCache
+        #$AccessToken = Get-AccessTokenFromCache -AccessToken $AccessToken -Resource "https://$Tenant.sharepoint.com/" -ClientId "9bc3ab49-b65d-410a-85ad-de819febfddc"
+        $headers["Authorization"] = "Bearer $at"
         $response=Invoke-WebRequest -UseBasicParsing -Uri "$Site" -Method Get -WebSession $siteSession  -Headers $headers  -ErrorAction SilentlyContinue 
         #$response=Invoke-WebRequest -UseBasicParsing -Uri "$Site/_api/SP.Directory.DirectorySession/Group('18fec963-bea7-469e-a6d7-ab69aa7de58b')/Members/Add(objectId='00000000-0000-0000-0000-000000000000', principalName='testa%4054824v%2Eonmicrosoft%2Ecom')" -Method Post -WebSession $siteSession -ContentType "application/json;odata=verbose" -ErrorAction SilentlyContinue  -Headers $headers 
         <#if($response.count -gt 4)

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -344,6 +344,7 @@ function Get-SPOSiteUserProperties
             $headers=@{
                 "Authorization" = "Bearer $AccessToken"
             }
+            Write-Host $AccessToken
         }
 
         # Invoke the request

--- a/SPO.ps1
+++ b/SPO.ps1
@@ -240,6 +240,8 @@ function Get-SPOUserProperties
 
         if($response.StatusCode -eq 200)
         {
+            Write-Host $siteSession
+            Write-Host $authHeader
             [xml]$response=$response.Content
             $entry=$response.entry
 
@@ -344,7 +346,6 @@ function Get-SPOSiteUserProperties
             $headers=@{
                 "Authorization" = "Bearer $AccessToken"
             }
-            Write-Host $AccessToken
         }
 
         # Invoke the request

--- a/SPO_utils.ps1
+++ b/SPO_utils.ps1
@@ -249,7 +249,7 @@ function Get-IDCRLToken
             # Oops, got an error?
             if([string]::IsNullOrEmpty($samlToken))
             {
-                if($error=$response.Envelope.Body.Fault.Detail.error.internalerror.text)
+                if($error -eq $response.Envelope.Body.Fault.Detail.error.internalerror.text)
                 {
                     Throw $error
                 }

--- a/SPO_utils.ps1
+++ b/SPO_utils.ps1
@@ -189,7 +189,7 @@ function Get-IDCRLToken
     Process
     {
         # Get the authentication realm info
-        [xml]$realmInfo = Get-UserRealmV2 -UserName $Credentials.UserName
+        $realmInfo = Get-UserRealmV2 -UserName $Credentials.UserName
 
         # Create the date strings
         $now=Get-Date
@@ -197,9 +197,9 @@ function Get-IDCRLToken
         $expires = $now.AddDays(1).ToUniversalTime().ToString("o")
 
         # Check the realm type. If federated, we must first get the SAML token
-        if($realmInfo.RealmInfo.NameSpaceType -eq "Federated")
+        if($realmInfo.NameSpaceType -eq "Federated")
         {
-            $url = $realmInfo.RealmInfo.STSAuthURL
+            $url = $realmInfo.STSAuthURL
 
             # Create the body
             $body=@"

--- a/SPO_utils.ps1
+++ b/SPO_utils.ps1
@@ -416,9 +416,6 @@ function Get-SPODigest
         $digest=$xmlContent.Envelope.Body.GetUpdatedFormDigestInformationResponse.GetUpdatedFormDigestInformationResult.DigestValue
         
         # Return the digest
-        Write-Host $Cookie
-        Write-Host $webCookie
-        Write-Host $AccessToken
         return $digest
     }
 }

--- a/SPO_utils.ps1
+++ b/SPO_utils.ps1
@@ -418,6 +418,7 @@ function Get-SPODigest
         # Return the digest
         Write-Host $Cookie
         Write-Host $webCookie
+        Write-Host $AccessToken
         return $digest
     }
 }

--- a/SPO_utils.ps1
+++ b/SPO_utils.ps1
@@ -313,7 +313,7 @@ function Get-IDCRLToken
         # Ooops, got an error?
         if([string]::IsNullOrEmpty($token))
         {
-            if($error=$response.Envelope.Body.Fault.Detail.error.internalerror.text)
+            if($error -eq $response.Envelope.Body.Fault.Detail.error.internalerror.text)
             {
                 Throw $error
             }

--- a/SPO_utils.ps1
+++ b/SPO_utils.ps1
@@ -416,6 +416,8 @@ function Get-SPODigest
         $digest=$xmlContent.Envelope.Body.GetUpdatedFormDigestInformationResponse.GetUpdatedFormDigestInformationResult.DigestValue
         
         # Return the digest
+        Write-Host $Cookie
+        Write-Host $webCookie
         return $digest
     }
 }

--- a/SPO_utils.ps1
+++ b/SPO_utils.ps1
@@ -189,7 +189,7 @@ function Get-IDCRLToken
     Process
     {
         # Get the authentication realm info
-        [xml]$realmInfo = Get-UserRealmV2 -UserName $Credentials.UserName -SPO
+        [xml]$realmInfo = Get-UserRealmV2 -UserName $Credentials.UserName
 
         # Create the date strings
         $now=Get-Date


### PR DESCRIPTION
This function allows a users to add a member to a site (and by doing that it also adds the user to the correlated group in Azure AD).
In order to run this function the user have to be group owner (requires not other privileges ) or to have a role that allows it to add a user to a group (global administrator, group administrator etc..).
 example:
![image](https://user-images.githubusercontent.com/88736901/189908611-ae6ef154-7e47-42ca-bb08-c10b110f55a2.png)

In addition, i fixed some errors in spo_utils.