### PR TITLE
Fixing TTS

### DIFF
--- a/OneNote.ps1
+++ b/OneNote.ps1
@@ -113,7 +113,7 @@ function Start-Speech
         
         try
         {
-            Set-BinaryContent -Path $mp3 -Value [byte[]](Convert-B64ToByteArray -B64 $mp3B64)
+            Set-BinaryContent -Path $mp3 -Value (Convert-B64ToByteArray -B64 $mp3B64)
 
             $player = [System.Windows.Media.MediaPlayer]::new()
             $player.Open($mp3)


### PR DESCRIPTION
Fixing #50, this is the error:
```
Set-BinaryContent : Cannot process argument transformation on parameter 'Value'. Cannot convert value "[byte[]]" to type "System.Byte[]". Error: "Cannot convert value "[byte[]]" to 
type "System.Byte". Error: "Input string was not in a correct format.""
At line:1 char:37
+ Set-BinaryContent -Path $mp3 -Value [byte[]](Convert-B64ToByteArray - ...
+                                     ~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Set-BinaryContent], ParameterBindingArgumentTransformationException
    + FullyQualifiedErrorId : ParameterArgumentTransformationError,Set-BinaryContent
```