### PR TITLE
Adding support to obtain partial TGT in Get-UserPRTKeys for Cloud Kerberos Trust deployments

### DIFF
--- a/PRT.ps1
+++ b/PRT.ps1
@@ -987,7 +987,11 @@ function Get-UserPRTKeys
         [System.Management.Automation.PSCredential]$Credentials,
 
         [Parameter(Mandatory=$False)]
-        [String]$OSVersion="10.0.18363.0"
+        [String]$OSVersion="10.0.18363.0",
+
+        [Parameter(Mandatory=$False)]
+        [switch]$IncludePartialTGT
+
     )
 
     Process
@@ -1091,6 +1095,11 @@ function Get-UserPRTKeys
             "client_info"         = "1"
         }
 
+        if ($IncludePartialTGT)
+        {
+            $body['tgt'] = $true
+        }
+
         # Make the request
         $response = Invoke-RestMethod -UseBasicParsing -Method Post -Uri "https://login.microsoftonline.com/$TenantId/oauth2/token" -ContentType "application/x-www-form-urlencoded" -Body $body -ErrorAction SilentlyContinue
 
@@ -1111,6 +1120,11 @@ function Get-UserPRTKeys
             }
             $sessionKey = Decrypt-JWE -JWE $response.session_key_jwe -PrivateKey $privateKey
             $response | Add-Member -NotePropertyName "session_key" -NotePropertyValue (Convert-ByteArrayToB64 -Bytes $sessionKey)
+            if ($IncludePartialTGT)
+            {
+                $tgt = Decrypt-JWE -JWE $response.tgt_client_key -SessionKey $sessionKey
+                $response | Add-Member -NotePropertyName "decrypted_tgt_client_key" -NotePropertyValue (Convert-ByteArrayToB64 -Bytes $tgt)
+            }
         }
         catch
         {


### PR DESCRIPTION
This is a simple addition that adds an additional parameter flag to Get-UserPRTKeys to request a partial TGT in the response. If the switch is set, it will also use the decrypted session key to decrypt the TGT client key that is accompanied with the partial TGT.