### PR TITLE
adding Get-AuthRedirectUrl within

### DIFF
--- a/PRT_Utils.ps1
+++ b/PRT_Utils.ps1
@@ -291,8 +291,6 @@ function Get-AccessTokenWithPRT
         [String]$Resource,
         [Parameter(Mandatory=$True)]
         [String]$ClientId,
-        [Parameter(Mandatory=$False)]
-        [String]$RedirectUri="urn:ietf:wg:oauth:2.0:oob",
         [switch]$GetNonce,
         [Parameter(Mandatory=$False)]
         [String]$Tenant
@@ -306,6 +304,9 @@ function Get-AccessTokenWithPRT
         }
 
         $parsedCookie = Read-Accesstoken $Cookie
+
+        #Set RedirectURI
+        $RedirectUri = Get-AuthRedirectUrl -ClientID $ClientId -Resource $Resource
 
         # Create parameters
         $mscrid =    (New-Guid).ToString()
@@ -331,12 +332,12 @@ function Get-AccessTokenWithPRT
         Write-Debug "RESPONSE: $($response.OuterXml)"
 
         # Try to parse the code from the response
-        if($response.html.body.script)
+        if ($response.html.body.h2.a.href)
         {
-            $values = $response.html.body.script.Split("?").Split("\")
+            $values = $response.html.body.h2.a.href.Split("?").Split("\").Split("&")
             foreach($value in $values)
             {
-                $row=$value.Split("=")
+               $row=$value.Split("=")
                 if($row[0] -eq "code")
                 {
                     $code = $row[1]


### PR DESCRIPTION
Get-AccessTokenWithPRT is currently failing when trying to get a Teams Access Token with a PRT. Get-AccessTokenWithPRT is currently hardcoded to use urn:ietf:wg:oauth:2.0:oob which is not a valid RedirectUrl for Teams. 

- Updated Get-AccessTokenWithPRT function to call the Get-AuthRedirectUrl, to get the correct RedirectUrl, and removed the hardcoded RedirectUrl paramater.

$response.html.body.script is not a valid property to parse the auth code from,
- Updated Get-AccessTokenWithPRT to look in $response.html.body.h2.a.href, and parse the auth code from their. 