### PR TITLE
Rename "ObjectId" in device certificate to "AuthUserObjectId"

### DIFF
--- a/Device.ps1
+++ b/Device.ps1
@@ -236,12 +236,12 @@ function Join-LocalDeviceToAzureAD
         $tenantId = $oids.TenantId
         $deviceId = $oids.DeviceId
 
-        Write-Verbose "Thumbprint: $thumbprint"
-        Write-Verbose "Device ID:  $deviceId"
-        Write-Verbose "Tenant ID:  $tenantId"
-        Write-Verbose "Object ID:  $($oids.ObjectId)"
-        Write-Verbose "Region:     $($oids.Region)"
-        Write-Verbose "Join Type:  $($oids.JoinType)"
+        Write-Verbose "Thumbprint:       $thumbprint"
+        Write-Verbose "Device ID:        $deviceId"
+        Write-Verbose "Tenant ID:        $tenantId"
+        Write-Verbose "Auth User Obj ID: $($oids.AuthUserObjectId)"
+        Write-Verbose "Region:           $($oids.Region)"
+        Write-Verbose "Join Type:        $($oids.JoinType)"
 
         if($oids.JoinType -eq 0)
         {
@@ -418,7 +418,7 @@ function Get-LocalDeviceJoinInfo
     CertPath           : Cert:\LocalMachine\My\CEC55C2566633AC8DA3D9E3EAD98A599084D0C4C
     TenantId           : afdb4be1-057f-4dc1-98a9-327ffa079cca
     DeviceId           : f4a4ea70-b196-4305-9531-018c3bcfc112
-    ObjectId           : d625e2e9-8465-4513-b6c9-8d34a3735d41
+    AuthUserObjectId   : d625e2e9-8465-4513-b6c9-8d34a3735d41
     KeyName            : 8bff0b7f02f6256b521de95a77d4e70d_934bc9f7-04ef-43d8-a343-610b736a4030
     KeyFriendlyName    : Device Identity Key
     IdpDomain          : login.windows.net
@@ -441,7 +441,7 @@ function Get-LocalDeviceJoinInfo
     CertPath           : Cert:\LocalMachine\My\FFDABA36622C66F1F9104703D77603AE1964E92B
     TenantId           : afdb4be1-057f-4dc1-98a9-327ffa079cca
     DeviceId           : e4c56ee8-419a-4421-bff4-1d3cb1c85ead
-    ObjectId           : b62a31e9-8268-485f-aba8-69696cdf3048
+    AuthUserObjectId   : b62a31e9-8268-485f-aba8-69696cdf3048
     KeyName            : C:\ProgramData\Microsoft\Crypto\PCPKSP\[redacted]\[redacted].PCPKEY
     KeyFriendlyName    : Device Identity Key
     IdpDomain          : login.windows.net
@@ -492,11 +492,11 @@ function Get-LocalDeviceJoinInfo
 
         $oids = Parse-CertificateOIDs -Certificate $certificate
 
-        $attributes["CertThumb"      ] = "$certThumbnail"
-        $attributes["CertPath"       ] = "Cert:\$certRoot\My\$certThumbnail"
-        $attributes["TenantId"       ] = $oids.TenantId
-        $attributes["DeviceId"       ] = $oids.DeviceId
-        $attributes["ObjectId"       ] = $oids.ObjectId
+        $attributes["CertThumb"       ] = "$certThumbnail"
+        $attributes["CertPath"        ] = "Cert:\$certRoot\My\$certThumbnail"
+        $attributes["TenantId"        ] = $oids.TenantId
+        $attributes["DeviceId"        ] = $oids.DeviceId
+        $attributes["AuthUserObjectId"] = $oids.AuthUserObjectId
 
         # This will fail for DeviceTransportKey because running as Local System
         try

--- a/Device_utils.ps1
+++ b/Device_utils.ps1
@@ -118,11 +118,16 @@ function Parse-CertificateOIDs
                "1.2.840.113556.1.5.284.2" {
                     $retVal | Add-Member -NotePropertyName "DeviceId" -NotePropertyValue ([guid][byte[]](Get-OidRawValue -RawValue $ext.RawData))
                 
-               } 
+               }
+
+               # "The objectGuid of the user object ([MS-ADSC] section 2.268) on the directory server that corresponds to the authenticating user."
+               # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dvrj/850786b9-2525-4047-a5ff-8c3093b46b88
+               # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dvre/76747b5c-06c2-4c73-9207-8ebb6ee891ea
+               # I.e. the object ID in AAD of the user who joined/registered the device
                "1.2.840.113556.1.5.284.3" {
-                    $retVal | Add-Member -NotePropertyName "ObjectId" -NotePropertyValue ([guid][byte[]](Get-OidRawValue -RawValue $ext.RawData))
+                    $retVal | Add-Member -NotePropertyName "AuthUserObjectId" -NotePropertyValue ([guid][byte[]](Get-OidRawValue -RawValue $ext.RawData))
                 
-               } 
+               }
                "1.2.840.113556.1.5.284.5" {
                     $retVal | Add-Member -NotePropertyName "TenantId" -NotePropertyValue ([guid][byte[]](Get-OidRawValue -RawValue $ext.RawData))
                 
@@ -136,14 +141,14 @@ function Parse-CertificateOIDs
                     # ME = Middle East
                     # NA = North America
                     # SA = South America
-                    $retVal | Add-Member -NotePropertyName "Region"   -NotePropertyValue ([text.encoding]::UTF8.getString([byte[]](Get-OidRawValue -RawValue $ext.RawData)))
+                    $retVal | Add-Member -NotePropertyName "Region" -NotePropertyValue ([text.encoding]::UTF8.getString([byte[]](Get-OidRawValue -RawValue $ext.RawData)))
                }
                "1.2.840.113556.1.5.284.7" {
                     # JoinType
                     # 0 = Registered
                     # 1 = Joined
                     $retVal | Add-Member -NotePropertyName "JoinType" -NotePropertyValue ([int]([text.encoding]::UTF8.getString([byte[]](Get-OidRawValue -RawValue $ext.RawData))))
-               }    
+               }
             }
         }
 

--- a/PRT.ps1
+++ b/PRT.ps1
@@ -350,12 +350,12 @@ function Join-DeviceToAzureAD
     PS\:>Join-AADIntDeviceToAzureAD -DeviceName "My computer" -DeviceType "Commodore" -OSVersion "C64"
 
     Device successfully registered to Azure AD:
-      DisplayName:     "My computer"
-      DeviceId:        d03994c9-24f8-41ba-a156-1805998d6dc7
-      ObjectId:        afdeac87-b32a-41a0-95ad-0a555a91f0a4
-      TenantId:        8aeb6b82-6cc7-4e33-becd-97566b330f5b
-      Cert thumbprint: 78CC77315A100089CF794EE49670552485DE3689
-      Cert file name : "d03994c9-24f8-41ba-a156-1805998d6dc7.pfx"
+      DisplayName:      "My computer"
+      DeviceId:         d03994c9-24f8-41ba-a156-1805998d6dc7
+      AuthUserObjectId: afdeac87-b32a-41a0-95ad-0a555a91f0a4
+      TenantId:         8aeb6b82-6cc7-4e33-becd-97566b330f5b
+      Cert thumbprint:  78CC77315A100089CF794EE49670552485DE3689
+      Cert file name :  "d03994c9-24f8-41ba-a156-1805998d6dc7.pfx"
     Local SID:
       S-1-5-32-544
     Additional SIDs:
@@ -368,12 +368,12 @@ function Join-DeviceToAzureAD
     PS\:>Join-AADIntDeviceToAzureAD -DeviceName "My computer" -DeviceType "Commodore" -OSVersion "C64" -JoinType Register
 
     Device successfully registered to Azure AD:
-      DisplayName:     "My computer"
-      DeviceId:        d03994c9-24f8-41ba-a156-1805998d6dc7
-      ObjectId:        afdeac87-b32a-41a0-95ad-0a555a91f0a4
-      TenantId:        8aeb6b82-6cc7-4e33-becd-97566b330f5b
-      Cert thumbprint: 78CC77315A100089CF794EE49670552485DE3689
-      Cert file name : "d03994c9-24f8-41ba-a156-1805998d6dc7.pfx"
+      DisplayName:      "My computer"
+      DeviceId:         d03994c9-24f8-41ba-a156-1805998d6dc7
+      AuthUserObjectId: afdeac87-b32a-41a0-95ad-0a555a91f0a4
+      TenantId:         8aeb6b82-6cc7-4e33-becd-97566b330f5b
+      Cert thumbprint:  78CC77315A100089CF794EE49670552485DE3689
+      Cert file name :  "d03994c9-24f8-41ba-a156-1805998d6dc7.pfx"
     Local SID:
       S-1-5-32-544
     Additional SIDs:
@@ -385,12 +385,12 @@ function Join-DeviceToAzureAD
     PS C\:>Join-AADIntDeviceToAzureAD -DeviceName "My computer" -SID "S-1-5-21-685966194-1071688910-211446493-3729" -PfxFileName .\f24f116f-6e80-425d-8236-09803da7dfbe-user.pfx -TenantId 40cb9912-555c-42b8-80e9-3b3ad50dda8a
 
     Device successfully registered to Azure AD:
-      DisplayName:     "My computer"
-      DeviceId:        f24f116f-6e80-425d-8236-09803da7dfbe
-      ObjectId:        afdeac87-b32a-41a0-95ad-0a555a91f0a4
-      TenantId:        8aeb6b82-6cc7-4e33-becd-97566b330f5b
-      Cert thumbprint: A531B73CFBAB2BA26694BA2AD31113211CC2174A
-      Cert file name : "f24f116f-6e80-425d-8236-09803da7dfbe.pfx"
+      DisplayName:      "My computer"
+      DeviceId:         f24f116f-6e80-425d-8236-09803da7dfbe
+      AuthUserObjectId: afdeac87-b32a-41a0-95ad-0a555a91f0a4
+      TenantId:         8aeb6b82-6cc7-4e33-becd-97566b330f5b
+      Cert thumbprint:  A531B73CFBAB2BA26694BA2AD31113211CC2174A
+      Cert file name :  "f24f116f-6e80-425d-8236-09803da7dfbe.pfx"
 
 #>
     [cmdletbinding()]
@@ -476,7 +476,7 @@ function Join-DeviceToAzureAD
         $oids = Parse-CertificateOIDs -Certificate $deviceCert
         $deviceId = $oids.DeviceId.ToString()
         $tenantId = $oids.TenantId.ToString()
-        $objectId = $oids.ObjectId.ToString()
+        $authUserObjectId = $oids.AuthUserObjectId.ToString()
 
         # Write the device certificate to disk
         Set-BinaryContent -Path "$deviceId.pfx" -Value $deviceCert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx)
@@ -485,12 +485,12 @@ function Join-DeviceToAzureAD
         Unload-PrivateKey -PrivateKey $deviceCert.PrivateKey
 
         Write-Host "Device successfully registered to Azure AD:"
-        Write-Host "  DisplayName:     ""$DeviceName"""
-        Write-Host "  DeviceId:        $deviceId"
-        Write-Host "  ObjectId:        $objectId"
-        Write-Host "  TenantId:        $tenantId"
-        Write-Host "  Cert thumbprint: $($regResponse.Certificate.Thumbprint)"
-        Write-host "  Cert file name : ""$deviceId.pfx"""
+        Write-Host "  DisplayName:      ""$DeviceName"""
+        Write-Host "  DeviceId:         $deviceId"
+        Write-Host "  AuthUserObjectId: $authUserObjectId"
+        Write-Host "  TenantId:         $tenantId"
+        Write-Host "  Cert thumbprint:  $($regResponse.Certificate.Thumbprint)"
+        Write-host "  Cert file name :  ""$deviceId.pfx"""
 
         foreach($change in $regResponse.MembershipChanges)
         {
@@ -865,12 +865,12 @@ function Get-UserPRTKeys
     PS C:\>Join-AADIntAzureAD -DeviceName "My computer" -DeviceType "Commodore" -OSVersion "C64"
 
     Device successfully registered to Azure AD:
-      DisplayName:     "My computer"
-      DeviceId:        d03994c9-24f8-41ba-a156-1805998d6dc7
-      ObjectId:        afdeac87-b32a-41a0-95ad-0a555a91f0a4
-      TenantId:        8aeb6b82-6cc7-4e33-becd-97566b330f5b
-      Cert thumbprint: 78CC77315A100089CF794EE49670552485DE3689
-      Cert file name : "d03994c9-24f8-41ba-a156-1805998d6dc7.pfx"
+      DisplayName:      "My computer"
+      DeviceId:         d03994c9-24f8-41ba-a156-1805998d6dc7
+      AuthUserObjectId: afdeac87-b32a-41a0-95ad-0a555a91f0a4
+      TenantId:         8aeb6b82-6cc7-4e33-becd-97566b330f5b
+      Cert thumbprint:  78CC77315A100089CF794EE49670552485DE3689
+      Cert file name :  "d03994c9-24f8-41ba-a156-1805998d6dc7.pfx"
     Local SID:
       S-1-5-32-544
     Additional SIDs:
@@ -889,12 +889,12 @@ function Get-UserPRTKeys
     PS C:\>Join-AADIntAzureAD -DeviceName "My computer" -DeviceType "Commodore" -OSVersion "C64"
 
     Device successfully registered to Azure AD:
-      DisplayName:     "My computer"
-      DeviceId:        d03994c9-24f8-41ba-a156-1805998d6dc7
-      ObjectId:        afdeac87-b32a-41a0-95ad-0a555a91f0a4
-      TenantId:        8aeb6b82-6cc7-4e33-becd-97566b330f5b
-      Cert thumbprint: 78CC77315A100089CF794EE49670552485DE3689
-      Cert file name : "d03994c9-24f8-41ba-a156-1805998d6dc7.pfx"
+      DisplayName:      "My computer"
+      DeviceId:         d03994c9-24f8-41ba-a156-1805998d6dc7
+      AuthUserObjectId: afdeac87-b32a-41a0-95ad-0a555a91f0a4
+      TenantId:         8aeb6b82-6cc7-4e33-becd-97566b330f5b
+      Cert thumbprint:  78CC77315A100089CF794EE49670552485DE3689
+      Cert file name :  "d03994c9-24f8-41ba-a156-1805998d6dc7.pfx"
     Local SID:
       S-1-5-32-544
     Additional SIDs:
@@ -913,12 +913,12 @@ function Get-UserPRTKeys
     PS C:\>Join-AADIntAzureAD -DeviceName "My computer" -DeviceType "Commodore" -OSVersion "C64"
 
     Device successfully registered to Azure AD:
-      DisplayName:     "My computer"
-      DeviceId:        d03994c9-24f8-41ba-a156-1805998d6dc7
-      ObjectId:        afdeac87-b32a-41a0-95ad-0a555a91f0a4
-      TenantId:        8aeb6b82-6cc7-4e33-becd-97566b330f5b
-      Cert thumbprint: 78CC77315A100089CF794EE49670552485DE3689
-      Cert file name : "d03994c9-24f8-41ba-a156-1805998d6dc7.pfx"
+      DisplayName:      "My computer"
+      DeviceId:         d03994c9-24f8-41ba-a156-1805998d6dc7
+      AuthUserObjectId: afdeac87-b32a-41a0-95ad-0a555a91f0a4
+      TenantId:         8aeb6b82-6cc7-4e33-becd-97566b330f5b
+      Cert thumbprint:  78CC77315A100089CF794EE49670552485DE3689
+      Cert file name :  "d03994c9-24f8-41ba-a156-1805998d6dc7.pfx"
     Local SID:
       S-1-5-32-544
     Additional SIDs:
@@ -1008,7 +1008,6 @@ function Get-UserPRTKeys
         $oids = Parse-CertificateOIDs -Certificate $Certificate
         $deviceId = $oids.DeviceId.ToString()
         $tenantId = $oids.TenantId.ToString()
-        $objectId = $oids.ObjectId.ToString()
 
         $body = "grant_type=srv_challenge" 
         


### PR DESCRIPTION
- Fix #56
- Corresponding reformatting
- Remove unused variable