### PR TITLE
Use Sort-Object instead of Sort on linux

### DIFF
--- a/AccessPackages.ps1
+++ b/AccessPackages.ps1
@@ -170,6 +170,6 @@ function Get-AccessPackageAdmins
         $accesspackages        | Select -ExpandProperty "modifiedBy" | %{ $names += $_}
 
         # Return unique usernames with upn
-        $names | Select-String -Pattern "@" | Sort | Get-Unique 
+        $names | Select-String -Pattern "@" | Sort-Object | Get-Unique 
     }
 }


### PR DESCRIPTION
When using AccessPackages, the powershell will return error with Sort is not defined. Use Sort-Object instead.