### PR TITLE
Get-UserPRTToken sometimes retrieving the wrong token

### DIFF
--- a/PRT.ps1
+++ b/PRT.ps1
@@ -109,7 +109,7 @@ function Get-UserPRTToken
             }
 
             # Return the data for x-ms-RefreshTokenCredential
-            $tokens = $response.response.data[$token_index]
+            $tokens = $response.response[$token_index].data
             return $tokens
         }
         else

--- a/PRT.ps1
+++ b/PRT.ps1
@@ -18,7 +18,7 @@ function Get-UserPRTToken
 
     .EXAMPLE
     PS C:\> Get-AADIntUserPRTToken
-    eyJ4NWMiOi...; path=/; domain=login.microsoftonline.com; secure; httponly
+    eyJ4NWMiOi...
 #>
     [cmdletbinding()]
     Param(
@@ -101,17 +101,16 @@ function Get-UserPRTToken
                 Throw "Error getting PRT: $($response.code). $($response.description)"
             }
 
-            # Return the last one
-            $tokens = $response.response.data
-            if($tokens.Count -gt 1)
+            # Get the index of the x-ms-RefreshTokenCredential data or throw error
+            $token_index = $response.response.name.IndexOf("x-ms-RefreshTokenCredential")
+            if($token_index -lt 0)
             {
-                return $tokens[$tokens.Count - 1]
+                throw "Could not find the x-ms-RefreshTokenCredential cookie in response"
             }
-            else
-            {
-                return $tokens
-            }
-                
+
+            # Return the data for x-ms-RefreshTokenCredential
+            $tokens = $response.response.data[$token_index]
+            return $tokens
         }
         else
         {
@@ -121,8 +120,15 @@ function Get-UserPRTToken
             {
                 Write-Verbose "Found $($tokens.Count) token(s)."
 
-                # Return the last one
-                $token = $tokens[$tokens.Count - 1]["data"]
+                # Get the index of the x-ms-RefreshTokenCredential data or throw error
+                $token_index = $tokens.name.IndexOf("x-ms-RefreshTokenCredential")
+                if($token_index -lt 0)
+                {
+                    throw "Could not find the x-ms-RefreshTokenCredential cookie in response"
+                }
+
+                # Return the data for x-ms-RefreshTokenCredential
+                $token = $tokens[$token_index]["data"]
                 
                 return $token.Split(";")[0]
             }


### PR DESCRIPTION
In some cases, `Get-UserPRTToken` will retrieve the `x-ms-DeviceCredential` cookie/token instead of the expected `x-ms-RefreshTokenCredential` token.

This causes the following documented workflow to fail:
<https://aadinternals.com/aadinternals/#get-aadintuserprttoken>

![image](https://github.com/Gerenios/AADInternals/assets/15148733/fffdade1-cd03-4e54-8988-505285f07854)

Digging into the issue a bit more...

![image](https://github.com/Gerenios/AADInternals/assets/15148733/ff30c107-a1bf-43c4-a71b-95abfe423b85)

The fix here is to find the correct index of `x-ms-RefreshTokenCredential` and return that token. With the fix, the above workflow works. 🙂 

![image](https://github.com/Gerenios/AADInternals/assets/15148733/5263fdb1-534c-426f-825a-115c0c108239)

Please go ahead and make any corrections I might have missed.

Cheers!