### PR TITLE
[FIX] aadsync_client_build 1.5.29.0 deprectated

### DIFF
--- a/AzureADConnectAPI_utils.ps1
+++ b/AzureADConnectAPI_utils.ps1
@@ -1,7 +1,7 @@
 ﻿# Initial AADSync server name
 $aadsync_server=        "adminwebservice.microsoftonline.com"
 $aadsync_client_version="8.0"
-$aadsync_client_build=  "1.5.29.0"
+$aadsync_client_build=  "2.2.8.0"
 
 # Checks whether the response has redirect
 function IsRedirectResponse


### PR DESCRIPTION
aadsync_client_build 1.5.29.0 deprectated

https://github.com/Gerenios/AADInternals/issues/76