### PR TITLE
Fix type mismatch in Get-TenantDomains

### DIFF
--- a/AccessToken_utils.ps1
+++ b/AccessToken_utils.ps1
@@ -1624,7 +1624,7 @@ function Get-TenantDomains
         $response = Invoke-RestMethod -UseBasicParsing -Method Post -uri $uri -Body $body -Headers $headers
 
         # Return
-		$domains = $response.Envelope.body.GetFederationInformationResponseMessage.response.Domains.Domain
+		$domains = @($response.Envelope.body.GetFederationInformationResponseMessage.response.Domains.Domain)
 		if($Domain -notin $domains)
         {
             $domains += $Domain


### PR DESCRIPTION
When the `Get-TenantDomains` function in `AccessToken_Utils.ps1` only returns a single domain a string value is returned for the assigned `$domains` variable. 

``` 
$domains = $response.Envelope.body.GetFederationInformationResponseMessage.response.Domains.Domain
```

This could cause a wrong concatenation in the following code block
```
if($Domain -notin $domains)
{
    $domains += $Domain
}
```

This in turn will ruin all subsequent checks as the the returned `$domains` is an incorrect concatenated string, instead of being an Array. This will cause AADInternals to show false information.

Applied Fix: Ensure `$domains` is always a StringArray