### PR TITLE
Add support for user dynamic group abuse (Get-DynamicAbusableGroups)

### DIFF
--- a/AADInternals.psd1
+++ b/AADInternals.psd1
@@ -226,6 +226,7 @@ DISCLAIMER: Functionality provided through this module are not supported by Micr
     "Get-AzureADFeatures"
     "Set-AzureADFeature"
     "Add-SyncFabricServicePrincipal"
+    "Get-DynamicAbusableGroups"
 
     # ProvisioningAPI.ps1
     "Set-DomainAuthentication"


### PR DESCRIPTION
This function returns Entra ID groups with user dynamic membership rule that contains attributes that can be modified by users. 
Related articles:
https://medium.com/r3d-buck3t/abusing-dynamic-groups-in-azuread-part-1-ff12e328c8c0
https://www.mnemonic.io/resources/blog/abusing-dynamic-groups-in-azure-ad-for-privilege-escalation/
Usage:
![image](https://github.com/Gerenios/AADInternals/assets/174818854/6bc81e5f-68c0-4f19-9d2f-3fac86e60348)
