### PR TITLE
Fixed AmbiguousParameterSet in Get-UserPRTKeys

### DIFF
--- a/PRT.ps1
+++ b/PRT.ps1
@@ -1023,7 +1023,8 @@ function Get-UserPRTKeys
         [Parameter(ParameterSetName='CloudAP'    ,Mandatory=$True)]
         [switch]$CloudAP,
 
-        [Parameter(ParameterSetName='CloudAP'    ,Mandatory=$True)]
+        [Parameter(ParameterSetName='CloudAP'        ,Mandatory=$True)]
+        [Parameter(ParameterSetName='FileAndPassword',Mandatory=$True)]
         [Parameter(Mandatory=$False)]
         [System.Management.Automation.PSCredential]$Credentials,
 


### PR DESCRIPTION
Running the function Get-UserPRTKeys with leads to the error Parameter set cannot be resolved using the specified named parameters (AmbiguousParameterSet) error

$prtKeys = Get-AADIntUserPRTKeys -Credentials $creds -PfxFileName .\d03994c9-24f8-41ba-a156-1805998d6dc7.pfx -TransportKeyFileName .\d03994c9-24f8-41ba-a156-1805998d6dc7_tk.pem

I added ParameterSetName='FileAndPassword' to the parameter $Credentials to resolve the conflict