### PR TITLE
Fixed IncludePartialTGT in Get-UserPRTKeys

### DIFF
--- a/PRT.ps1
+++ b/PRT.ps1
@@ -1231,7 +1231,8 @@ function Get-UserPRTKeys
 
                 if ($IncludePartialTGT)
                 {
-                    $tgt = Decrypt-JWE -JWE $response.tgt_client_key -SessionKey $sessionKey
+                    $tgt_cloud = ConvertFrom-Json $response.tgt_cloud
+                    $tgt = Decrypt-JWE -JWE $tgt_cloud.clientKey -SessionKey $sessionKey
                     $response | Add-Member -NotePropertyName "decrypted_tgt_client_key" -NotePropertyValue (Convert-ByteArrayToB64 -Bytes $tgt)
                 }
 


### PR DESCRIPTION
tgt_client_key is currently not returned by https://login.microsoftonline.com/$TenantId/oauth2/token. The TGT client key is returned within the (JSON string) value of tgt_cloud, like:

"tgt_cloud":  "{\"clientKey\":\"eyJhbGciOiJkaXIiLCJlb...\",\"keyType\":18,\"messageBuffer\":\"a4IIY...",\"realm\":\"KERBEROS.MICROSOFTONLINE.COM\",\"sn\":\"krbtgt/KERBEROS.MICROSOFTONLINE.COM\",\"cn\":\"USER@DOMAIN.onmicrosoft.com\",\"sessionKeyType\":0,\"accountType\":2}"