### PR TITLE
PowerShell 7 compatibility fix

### DIFF
--- a/CommonUtils.ps1
+++ b/CommonUtils.ps1
@@ -2891,6 +2891,11 @@ Function Invoke-WebRequest2
             $arguments["WebSession"] = $WebSession
         }
 
+        # PSVersions >= 7 set undeclared OutFile as empty string which makes the Invoke-WebRequest fail
+        if(($PSVersionTable.PSVersion.Major -ge 7) -and ($arguments["OutFile"] -eq "")) 
+        {
+            $arguments.Remove("OutFile")
+        }    
         # PSVersions >= 7 doesn't respect the ErrorAction SilentlyContinue so we need to use SkipHttpErrorCheck
         if(($PSVersionTable.PSVersion.Major -ge 7) -and ($ErrorActionPreference -eq "SilentlyContinue"))
         {


### PR DESCRIPTION
It looks like PowerShell v7 behaves differently and instead of OutFile set to Null it sets it to empty string. It makes the following call to Invoke-WebRequest to fail:

    Invoke-WebRequest: C:\Program Files\WindowsPowerShell\Modules\AADInternals\0.9.4\CommonUtils.ps1:2899:27
    Line |
    2899 |          Invoke-WebRequest @arguments
         |                            ~~~~~~~~~~
         | Cannot validate argument on parameter 'OutFile'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.

It should fix the issue #94 