### PR TITLE
fix: Export-AADIntLocalDeviceTransportKey make email optional

### DIFF
--- a/Device_utils.ps1
+++ b/Device_utils.ps1
@@ -13,7 +13,7 @@ function Get-LocalDeviceTransportKeys
         [String]$IdpDomain,
         [Parameter(Mandatory=$True)]
         [String]$TenantId,
-        [Parameter(Mandatory=$True)]
+        [Parameter(Mandatory=$False)]
         [String]$UserEmail
     )
     Begin


### PR DESCRIPTION
Simple one line fix to make email argument optional on Export-AADIntLocalDeviceTransportKey. 

For use case where a device is connected via a Managed Identity. Previously the function had an error due to the join info "email" being empty.

After checking my device and regedit.msc I realized I had the necessary private key and since my device was "Joined" the if branch in the function I would be using didn't require email. 

Changed to make email optional and everything worked.