### PR TITLE
fix: Autodiscover User-Agent

### DIFF
--- a/AccessToken_utils.ps1
+++ b/AccessToken_utils.ps1
@@ -1369,7 +1369,7 @@ function Get-TenantDomains
         $headers=@{
             "Content-Type" = "text/xml; charset=utf-8"
             "SOAPAction" =   '"http://schemas.microsoft.com/exchange/2010/Autodiscover/Autodiscover/GetFederationInformation"'
-            "User-Agent" =   Get-UserAgent
+            "User-Agent" =   "AutodiscoverClient"
         }
         # Invoke
         $response = Invoke-RestMethod -UseBasicParsing -Method Post -uri $uri -Body $body -Headers $headers


### PR DESCRIPTION
Reverts the change made in [v0.9.4](https://github.com/Gerenios/AADInternals/blame/0fa2edf5676439cd3fe7c92ed8006b63f0be9632/AccessToken_utils.ps1#L1611) to resolve https://github.com/Gerenios/AADInternals/issues/114

Microsoft appears to have changed GetFederationInformation  behavior in response to requests without "AutodiscoverClient" in the User-Agent header. If this string is missing, the response will contain only one domain and throw errors.

In case it is preferred to keep the AADInternals fingerprint on requests, testing also succeeded with: 
` "User-Agent" =    "AutodiscoverClient $(Get-UserAgent)"`