### PR TITLE
Fix tenant name lookup and Domain Resolution in Invoke-AADIntReconAsOutsider

### DIFF
--- a/AADInternals.psd1
+++ b/AADInternals.psd1
@@ -181,6 +181,7 @@ DISCLAIMER: Functionality provided through this module are not supported by Micr
     "Get-OpenIDConfiguration"
     "Get-TenantId"
     "Get-TenantDomains"
+    "Get-TenantDomainsFromACS"
     "Get-Cache"
     "Clear-Cache"
     "Add-AccessTokenToCache"

--- a/AccessToken_utils.ps1
+++ b/AccessToken_utils.ps1
@@ -1303,7 +1303,13 @@ function Get-TenantDomainsFromACS
     registered email domains (allowedAudiences) for a tenant. This endpoint returns
     domains that are registered with the tenant for email routing and federation purposes.
 
-    Requires the tenant's initial domain name (*.onmicrosoft.com).
+    Requires the tenant's initial domain name (*.onmicrosoft.com or *.onmicrosoft.us for gov clouds).
+
+    .Parameter TenantName
+    The tenant's initial domain name (e.g., company.onmicrosoft.com, company.onmicrosoft.us)
+
+    .Parameter SubScope
+    Optional tenant subscope/region identifier (DOD, DODCON, etc.)
 
     .Example
     Get-AADIntTenantDomainsFromACS -TenantName company.onmicrosoft.com
@@ -1312,18 +1318,43 @@ function Get-TenantDomainsFromACS
     company.mail.onmicrosoft.com
     company.onmicrosoft.com
 
+    .Example
+    Get-AADIntTenantDomainsFromACS -TenantName company.onmicrosoft.us -SubScope DOD
+
+    company.com
+    company.mail.onmicrosoft.us
+    company.onmicrosoft.us
+
 #>
     [cmdletbinding()]
     Param(
         [Parameter(Mandatory=$True)]
-        [String]$TenantName
+        [String]$TenantName,
+        [Parameter(Mandatory=$False)]
+        [String]$SubScope
     )
     Process
     {
         try
         {
-            # Build the ACS metadata endpoint URL
-            $uri = "https://accounts.accesscontrol.windows.net/$TenantName/metadata/json/1"
+            # Build the ACS metadata endpoint URL based on cloud environment
+            # Reference: https://learn.microsoft.com/en-us/exchange/configure-oauth-authentication-between-exchange-and-exchange-online-organizations-exchange-2013-help
+            # Note: Government clouds use login.microsoftonline.us instead of accounts.accesscontrol
+            switch($SubScope)
+            {
+                "DOD" # DoD
+                {
+                    $uri = "https://login.microsoftonline.us/$TenantName/metadata/json/1"
+                }
+                "DODCON" # GCC-High
+                {
+                    $uri = "https://login.microsoftonline.us/$TenantName/metadata/json/1"
+                }
+                default # Commercial/GCC
+                {
+                    $uri = "https://accounts.accesscontrol.windows.net/$TenantName/metadata/json/1"
+                }
+            }
             
             Write-Verbose "Querying ACS metadata endpoint: $uri"
             
@@ -1331,7 +1362,8 @@ function Get-TenantDomainsFromACS
             $response = Invoke-RestMethod -Uri $uri -UseBasicParsing -ErrorAction Stop
             
             # Extract domains from allowedAudiences
-            # Format: 00000001-0000-0000-c000-000000000000/accounts.accesscontrol.windows.net@<domain>
+            # Format (Commercial): 00000001-0000-0000-c000-000000000000/accounts.accesscontrol.windows.net@<domain>
+            # Format (Gov clouds): 00000001-0000-0000-c000-000000000000/login.microsoftonline.us@<domain>
             $domains = @()
             if($response.allowedAudiences)
             {
@@ -1509,7 +1541,7 @@ function Get-TenantDomains
             if(![string]::IsNullOrEmpty($tenantName))
             {
                 Write-Verbose "Using tenant name: $tenantName for ACS query"
-                $acsDomains = Get-TenantDomainsFromACS -TenantName $tenantName
+                $acsDomains = Get-TenantDomainsFromACS -TenantName $tenantName -SubScope $SubScope
                 
                 if($acsDomains.Count -gt 0)
                 {

--- a/KillChain.ps1
+++ b/KillChain.ps1
@@ -1,4 +1,4 @@
-﻿#
+#
 # This file contains functions for Azure AD / Office 365 kill chain
 #
 
@@ -240,6 +240,19 @@ function Invoke-ReconAsOutsider
                 }
                 Remove-Variable "relayingParties" -ErrorAction SilentlyContinue
                 $domainInformation += New-Object psobject -Property $attributes
+            }
+        }
+
+        # Fallback: If tenant name was not found from autodiscover, try alternative method
+        if([string]::IsNullOrEmpty($tenantName))
+        {
+            Write-Verbose "Tenant name not found from autodiscover, trying alternative method..."
+            $tenantName = Get-TenantNameByTenantId -TenantId $tenantId -SubScope $tenantSubscope -Domain $DomainName
+            
+            # If still not found, give user a hint
+            if([string]::IsNullOrEmpty($tenantName))
+            {
+                Write-Warning "Tenant name lookup requires authentication. Run 'Get-AADIntAccessTokenForMSGraph -SaveToCache' first (can use any tenant)."
             }
         }
 

--- a/KillChain.ps1
+++ b/KillChain.ps1
@@ -282,7 +282,7 @@ function Invoke-ReconAsOutsider
         }
 
         # Cloud sync not definitive, may use different domain name
-        if(DoesUserExists -User "ADToAADSyncServiceAccount@$($tenantName)")
+        if(![string]::IsNullOrEmpty($tenantName) -and (DoesUserExists -User "ADToAADSyncServiceAccount@$($tenantName)"))
         {
             Write-Host "Uses cloud sync:    $true"
         }


### PR DESCRIPTION
## Problem   
Microsoft changed their Exchange Online autodiscover API responses and we can't list all the related domains anymore.
My personal issue was that the tenant name was also missing and could no longer be retrieved.   
<img width="847" height="327" alt="image" src="https://github.com/user-attachments/assets/4e8cde3e-f74b-43ba-9cd0-301641ed8b73" />


## Solution    
Added a fallback mechanism using DKIM DNS records to reliably extract the tenant's initial *.onmicrosoft.com domain without authentication.    
Added another fallback to query the default domain via Graph but that needs authentication to a dummy / any domain.   

## How it works     
DKIM CNAME records for Exchange Online domains point to:   

```
selector1-<domain>._domainkey.<tenantname>.onmicrosoft.com
```

By querying these DNS records and extracting the tenant name portion, we can reliably identify the *.onmicrosoft.com domain.   

## Changes   
KillChain.ps1 (lines 247-256)   

Added fallback call to ``Get-TenantNameByTenantId`` when autodiscover doesn't return tenant name   
Added warning message when tenant name cannot be determined   
KillChain_utils.ps1 (lines 444-528)   

Added new function ``Get-TenantNameByTenantId`` with two methods:  
DKIM records (unauthenticated) - Queries ``selector1._domainkey.<domain>`` CNAME records and extracts tenant name from the target, then verifies tenant ID matches  
MS Graph API (authenticated fallback) - Uses tenantRelationships/findTenantInformationByTenantId to get defaultDomainName if DKIM method fails and user has cached token  

## Limitations
DKIM method only works if domain has Exchange Online DKIM configured  
MS Graph fallback returns defaultDomainName which may be a custom domain, not *.onmicrosoft.com  
Domains not using Exchange Online will show empty tenant name unless authenticated  

So it is something but not suitable for all cases.

<img width="590" height="303" alt="image" src="https://github.com/user-attachments/assets/aeeb53ed-1f1b-4bf1-a208-7afc84dafb9e" />

<img width="935" height="307" alt="image" src="https://github.com/user-attachments/assets/534a5aaf-a962-41fa-b5e1-8ab80298214d" />

<img width="934" height="461" alt="image" src="https://github.com/user-attachments/assets/b3babed3-8748-4b61-b73f-2d594e9ffe28" />

Also partly mentioned here:
https://github.com/Gerenios/AADInternals/issues/114#issuecomment-3011231339